### PR TITLE
Update Dockerfile to use nightly Rust and install dependencies

### DIFF
--- a/mayhem/Dockerfile
+++ b/mayhem/Dockerfile
@@ -1,5 +1,14 @@
 # Build Stage
 FROM ghcr.io/evanrichter/cargo-fuzz:latest as builder
+FROM rustlang/rust:nightly AS builder
+
+RUN apt update && apt upgrade -y && \
+    apt install -y clang-19 llvm-19-tools && \
+    ln -s /usr/bin/llvm-config-19 /usr/bin/llvm-config
+
+RUN rustup component add rust-src
+RUN cargo install -f cargo-fuzz
+RUN cargo install -f cargo-afl
 
 ## Add source code to the build stage.
 ADD . /src


### PR DESCRIPTION
Switch to using rustlang/rust:nightly as the builder base image and install additional dependencies for fuzzing.